### PR TITLE
Removed $q dep, opts passing, optimized promises

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -11,10 +11,10 @@ var osmAPIModule = angular.module('osm.api', [
     this.options = {
         url: 'http://api.openstreetmap.org/api'
     };
-    this.$get = function osmAPIFactory($http, $q, osmx2js) {
-        return new osmAPI($http, $q, osmx2js, this.options);
+    this.$get = ($http, osmx2js) => {
+        return new osmAPI($http, osmx2js, this.options);
     };
-    this.$get.$inject = ['$http', '$q', 'osmx2js'];
+    this.$get.$inject = ['$http', 'osmx2js'];
 });
 
 export default osmAPIModule;

--- a/src/api/api.spec.js
+++ b/src/api/api.spec.js
@@ -6,7 +6,7 @@
 
 ngDescribe({
     modules: ['osm.api'],
-    inject: ['osmAPI', 'osmx2js', '$q', '$http', '$httpBackend', '$rootScope'],
+    inject: ['osmAPI', 'osmx2js', '$http', '$httpBackend', '$rootScope'],
     tests: function (deps) {
         function setHTTPAdapter(deps) {
             var adapter = {
@@ -48,7 +48,7 @@ ngDescribe({
         it('should internal xhr works as expected', function() {
             var backend = {
                 xhr: function(options) {
-                    return deps.$q.when({data: 'data'});
+                    return Promise.resolve({data: 'data'});
                 }
             };
             deps.osmAPI.setAuthAdapter(backend);


### PR DESCRIPTION
* in api, this.options was not passed to osmAPI
* removed the need for $q - native promises are better
* in many cases, there was a wrapping for promises

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/toutpt/angular-osm/blob/master/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
